### PR TITLE
Refactoring lib/scheduler, secc-scheduler and Added some functions

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -1,21 +1,77 @@
 'use strict';
 
+/**
+ * Module dependenices.
+ */
+
 var debug = require('debug')('secc:scheduler');
 var path = require('path');
+var express = require('express');
+var bodyParser = require('body-parser');
+var multer  = require('multer')
+var compression = require('compression')
 
-var Scheduler = function(SECC) {
-  if (typeof SECC.archivePath === 'undefined')
+
+/**
+ * Exports scheduler.
+ */
+
+module.exports = Scheduler;
+
+
+/**
+ * Scheduler Object.
+ * 
+ * @param {Settings} SECC
+ */
+
+function Scheduler(SECC) {
+  if (!(this instanceof Scheduler)) {
+    return new Scheduler(SECC);
+  }
+
+  if (typeof SECC === 'undefined') {
+    console.log('SECC is null');
+    return;
+  }
+  if (typeof SECC.archivePath === 'undefined') {
     SECC.archivePath = path.join(__dirname, '..', 'archive');
+  }
 
-  var express = require('express');
+  if (typeof SECC.uploadPath === 'undefined') {
+    SECC.uploadPath = path.join(__dirname, '..', 'uploads');
+  }
+
+  this.SECC = SECC;
+  this.server = null;
+  this.sockets = {};
+  this.nextSocketId = 0;
+}
+
+function isEmptyObject(obj) {
+  return Object.keys(obj).length == 0 ? true : false;
+}
+
+/**
+ * Init http server
+ */
+
+Scheduler.prototype.initServer = function(successCallback, failureCallback) {
+  var self = this;
+
+  if (!isEmptyObject(self.sockets)) {
+    failureCallback('Already server is initialized.');
+    return;
+  }
+
+  var SECC = this.SECC;
   var app = express();
   var server = require('http').Server(app);
-  var io = require('socket.io')(server);
+  var io = require('socket.io')(server);  
+  var upload = multer({dest:SECC.uploadPath}).single('archiveFile'); 
 
-  var bodyParser = require('body-parser');
-  var multer  = require('multer')
-  var compression = require('compression')
-  var upload = multer({dest:'./uploads/'}).single('archiveFile');
+  // set member variable
+  this.server = server;
 
   app.set('views', path.join(__dirname, '..', 'views'));
   app.set('view engine', 'ejs');
@@ -44,12 +100,12 @@ var Scheduler = function(SECC) {
 
   //WebSocket and routers
   var schedulerWebSocket = require('../routes/schedulerWebSocket')(express, io, SECC, SCHEDULER);
-  var schedulerIndex     = require('../routes/schedulerIndex')(express, io, SECC, SCHEDULER);
-  var schedulerArchive   = require('../routes/schedulerArchive')(express, io, SECC, SCHEDULER);
-  var schedulerCache     = require('../routes/schedulerCache')(express, io, SECC, SCHEDULER);
-  var schedulerDaemon    = require('../routes/schedulerDaemon')(express, io, SECC, SCHEDULER);
-  var schedulerJob       = require('../routes/schedulerJob')(express, io, SECC, SCHEDULER);
-  var schedulerOption    = require('../routes/schedulerOption')(express, io, SECC, SCHEDULER);
+  var schedulerIndex = require('../routes/schedulerIndex')(express, io, SECC, SCHEDULER);
+  var schedulerArchive = require('../routes/schedulerArchive')(express, io, SECC, SCHEDULER);
+  var schedulerCache = require('../routes/schedulerCache')(express, io, SECC, SCHEDULER);
+  var schedulerDaemon = require('../routes/schedulerDaemon')(express, io, SECC, SCHEDULER);
+  var schedulerJob = require('../routes/schedulerJob')(express, io, SECC, SCHEDULER);
+  var schedulerOption = require('../routes/schedulerOption')(express, io, SECC, SCHEDULER);
 
   app.use('/', schedulerIndex);
   app.use('/archive/', schedulerArchive);
@@ -58,9 +114,92 @@ var Scheduler = function(SECC) {
   app.use('/job/', schedulerJob);
   app.use('/option/', schedulerOption);
 
-  //FIXME : return new Scheduler(SECC)
-  //        and Scheduler.prototype.startServer() etc.
-  return server;
+  successCallback('Server is initialize');
 }
 
-module.exports = Scheduler;
+
+/**
+ * Start scheduer method
+ */
+Scheduler.prototype.startServer = function(successCallback, failureCallback) {
+  var self = this;
+
+  self.initServer(function(msg){
+    console.log(msg);
+
+    var SECC = self.SECC || false;
+    var server = self.server || false;
+
+    if(!SECC || !server) {
+      console.log('Object is null');
+      return;
+    }
+
+    // Server start listening
+    server.listen(SECC.scheduler.port, function() {
+      var host = server.address().address;
+      var port = server.address().port;
+
+      console.log('secc-scheduler listening at http://%s:%s', host, port);
+    });
+
+    // Server connection event
+    server.on('connection', function (socket) {
+      // Add a newly connected socket
+      var socketId = self.nextSocketId++;
+      self.sockets[socketId] = socket;
+      console.log('socket', socketId, 'opened');
+
+      // Remove the socket when it closes
+      socket.on('close', function () {
+        console.log('socket', socketId, 'closed');
+        delete self.sockets[socketId];
+      });
+    });
+
+    // when server created successfully, call successCallback. 
+    successCallback('Server is running!');
+
+  }, function(msg) {
+    failureCallback(msg);
+  });
+}
+
+
+/**
+ * Stop scheduer method
+ */
+Scheduler.prototype.stopServer = function(successCallback, failureCallback) {
+  var self = this;
+
+  if(!isEmptyObject(self.sockets)) {
+    // Before close is called, it check handle===0 && connections===0.
+    // If connections exist, do not working close event.
+    self.server.getConnections(function(err, count) {
+      console.log('connections:'+count);
+
+      if (count) {
+        // destroy all sockes
+        for (var socketId in self.sockets) {
+          console.log('socket', socketId, 'destroyed');
+          self.sockets[socketId].destroy();
+        }
+
+        self.server.close(function(){
+          console.log('Closed Server....');
+
+          self.nextSocketId = 0;
+          self.server = null;
+          self.sockets = {};
+        });
+
+        successCallback('Server is stopping!');
+      }
+
+    });
+  } else {
+    failureCallback('Already server is stopped');
+  }
+}
+
+/* End of File */

--- a/secc-scheduler.js
+++ b/secc-scheduler.js
@@ -1,11 +1,21 @@
 'use strict';
 
+var path = require('path');
+var archivePath = path.join(__dirname, "archive");
+var uploadPath = path.join(__dirname, "uploads");
 var SECC = require('./settings.json');
-var server = require('./lib/scheduler')(SECC);
 
-server.listen(SECC.scheduler.port, function () {
-  var host = server.address().address;
-  var port = server.address().port;
+SECC.archivePath = archivePath;
+SECC.uploadPath = uploadPath;
 
-  console.log('secc-scheduler listening at http://%s:%s', host, port);
-});
+var scheduler = require('./lib/scheduler')(SECC);
+
+function success(msg) {
+    console.log(msg);
+}
+
+function failure(msg) {
+    console.log(msg);
+}
+
+scheduler.startServer(success, failure);


### PR DESCRIPTION
**1. Refactoring lib/scheduler, secc-scheduler and Added some functions**
lib/scheduler.js
ㄴ scheduler.prototype.initServer
ㄴ scheduler.prototype.startServer
ㄴ scheduler.prototype.stopServer

> Each functions has success and failure callback.
> Each functions can be implemented to create a duplicate impossible.
> It means, If already server is created, Do not create duplicate server
> object.

**2. Replace double quotes -> single quotes**
**3. Remove all white space**
**4. In case of use to require func, do not need path.join**
   Remove path.join in require func
