### PR TITLE
Use debug instead of console.log, change successCalback position

### DIFF
--- a/lib/scheduler.js
+++ b/lib/scheduler.js
@@ -31,7 +31,7 @@ function Scheduler(SECC) {
   }
 
   if (typeof SECC === 'undefined') {
-    console.log('SECC is null');
+    debug('SECC is null');
     return;
   }
   if (typeof SECC.archivePath === 'undefined') {
@@ -125,13 +125,13 @@ Scheduler.prototype.startServer = function(successCallback, failureCallback) {
   var self = this;
 
   self.initServer(function(msg){
-    console.log(msg);
+    debug(msg);
 
     var SECC = self.SECC || false;
     var server = self.server || false;
 
     if(!SECC || !server) {
-      console.log('Object is null');
+      debug('Object is null');
       return;
     }
 
@@ -140,7 +140,7 @@ Scheduler.prototype.startServer = function(successCallback, failureCallback) {
       var host = server.address().address;
       var port = server.address().port;
 
-      console.log('secc-scheduler listening at http://%s:%s', host, port);
+      debug('secc-scheduler listening at http://%s:%s', host, port);
     });
 
     // Server connection event
@@ -148,11 +148,11 @@ Scheduler.prototype.startServer = function(successCallback, failureCallback) {
       // Add a newly connected socket
       var socketId = self.nextSocketId++;
       self.sockets[socketId] = socket;
-      console.log('socket', socketId, 'opened');
+      debug('socket', socketId, 'opened');
 
       // Remove the socket when it closes
       socket.on('close', function () {
-        console.log('socket', socketId, 'closed');
+        debug('socket', socketId, 'closed');
         delete self.sockets[socketId];
       });
     });
@@ -176,27 +176,26 @@ Scheduler.prototype.stopServer = function(successCallback, failureCallback) {
     // Before close is called, it check handle===0 && connections===0.
     // If connections exist, do not working close event.
     self.server.getConnections(function(err, count) {
-      console.log('connections:'+count);
+      debug('connections:'+count);
 
       if (count) {
         // destroy all sockes
         for (var socketId in self.sockets) {
-          console.log('socket', socketId, 'destroyed');
+          debug('socket', socketId, 'destroyed');
           self.sockets[socketId].destroy();
         }
 
         self.server.close(function(){
-          console.log('Closed Server....');
+          debug('Closed Server....');
 
           self.nextSocketId = 0;
           self.server = null;
           self.sockets = {};
+
+          successCallback('Server is stopping!');
         });
-
-        successCallback('Server is stopping!');
       }
-
-    });
+    }); // end getConnections
   } else {
     failureCallback('Already server is stopped');
   }


### PR DESCRIPTION
- Use debug instead of console.log.
- Change successCalback position, which should be called in self.server.close.
